### PR TITLE
Only run update-dotorg-assets manually on workflow_dispatch

### DIFF
--- a/.github/workflows/update-dotorg-assets.yml
+++ b/.github/workflows/update-dotorg-assets.yml
@@ -1,12 +1,13 @@
 name: Update assets on WordPress.org
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - 'README.md'
-            - '.wordpress.org/**'
+    workflow_dispatch:
+#    push:
+#        branches:
+#            - main
+#        paths:
+#            - 'README.md'
+#            - '.wordpress.org/**'
 
 jobs:
     update:


### PR DESCRIPTION
This will avoid accidental asset/readme updates, such as when merging into `main` prior to having created the release tag.