### PR TITLE
Ensure `is_user_logged_in()` function exists before using

### DIFF
--- a/includes/bfcache-opt-in.php
+++ b/includes/bfcache-opt-in.php
@@ -416,7 +416,7 @@ function filter_nocache_headers( $headers ): array {
 	}
 
 	// If a user is logged in, then enabling bfcache is contingent upon the "Remember Me" opt-in and JS being enabled, since bfcache invalidation becomes important.
-	if ( is_user_logged_in() ) {
+	if ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
 		// Abort if the user session doesn't have bfcache enabled since they hadn't logged in with "Remember Me" and JavaScript enabled.
 		$bfcache_session_token = get_user_bfcache_session_token();
 		if ( null === $bfcache_session_token ) {


### PR DESCRIPTION
This fixes an issue where if a plugin calls `wp_die()` too early, a fatal error can occur due to `is_user_logged_in()` not being defined. This is because `is_user_logged_in()` is a pluggable function, so plugins are able to override it. So it is not guaranteed to exist.