### PR TITLE
Add documentation for configuring repo for workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,26 @@
+# Repository Configuration Workflows
+
+## [`auto-merge.yml`](auto-merge.yml)
+
+The workflow depends on a `WORKFLOW_TOKEN` dependabot secret. Create a [fine-grained token](https://github.com/settings/personal-access-tokens) with the following permissions:
+
+* Metadata: read (required)
+* Contents: read and write
+* Pull requests: read and write
+
+Then add this as the `WORKFLOW_SECRET` to the repository's settings under **Security > Secrets and variables > Dependabot** (`./settings/secrets/dependabot`).
+
+## [`deploy-dotorg.yml`](deploy-dotorg.yml)
+
+This workflow is triggered when a new release tag is created.
+
+The workflow requires two action secrets to be populated as required by [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy): `SVN_USERNAME` and `SVN_PASSWORD`. These are the username and password for a WordPress.org user account which has commit access to the SVN repo. The SVN credentials can be located at `https://profiles.wordpress.org/$DOTORG_USERNAME/profile/edit/group/3/?screen=svn-password`, where the SVN password begins with "svn_".
+
+Add these secrets to repository's settings under **Security > Secrets and variables > Actions** (`./settings/secrets/actions`).
+
+## [`update-dotorg-assets.yml`](update-dotorg-assets.yml)
+
+This workflow is triggered manually when accessing "Run workflow" from the workflow located on the Actions screen.
+
+The workflow requires two action secrets to be populated as required by [10up/action-wordpress-plugin-asset-update](https://github.com/10up/action-wordpress-plugin-deploy): `SVN_USERNAME` and `SVN_PASSWORD`. See the `deploy-dotorg.yml` section above. 
+

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -14,6 +14,8 @@ jobs:
     release:
         name: Publish release
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -70,4 +72,4 @@ jobs:
               if: github.event_name == 'release'
               run: gh release upload ${{ github.event.release.tag_name }} *.zip
               env:
-                  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also try setting write permissions in the `deploy-dotorg.yml` workflow so `GITHUB_TOKEN` can be used instead of a custom `WORKFLOW_TOKEN`.