### PR TITLE
Rename plugin to "Instant Back/Forward"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# No-cache BFCache
+# Instant Back/Forward
 
 Enables back/forward cache (bfcache) for instant history navigations even when “nocache” headers are sent, such as when a user is logged in.
 
 <!-- markdownlint-disable-next-line no-inline-html -->
-<img src=".wordpress-org/banner.svg" alt="Banner for the No-cache BFCache plugin" width="1544" height="500">
+<img src=".wordpress-org/banner.svg" alt="Banner for the Instant Back/Forward plugin" width="1544" height="500">
 
 **Contributors:** [westonruter](https://profile.wordpress.org/westonruter), [wordpressdotorg](https://profile.wordpress.org/wordpressdotorg), [performanceteam](https://profile.wordpress.org/performanceteam)  
 **Tags:**         performance, caching  
@@ -66,8 +66,8 @@ With bfcache:
 ### Installation from within WordPress
 
 1. Visit **Plugins > Add New** in the WordPress Admin.
-2. Search for **No-cache BFCache**.
-3. Install and activate the **No-cache BFCache** plugin.
+2. Search for **Instant Back/Forward**.
+3. Install and activate the **Instant Back/Forward** plugin.
 4. Log out of WordPress and log back in with the “Remember Me” checkbox checked.
 
 You may also install and update via [Git Updater](https://git-updater.com/) using the [plugin's GitHub URL](https://github.com/westonruter/nocache-bfcache).

--- a/includes/bfcache-invalidation.php
+++ b/includes/bfcache-invalidation.php
@@ -28,7 +28,7 @@ function enqueue_bfcache_invalidation_script_modules(): void {
 	}
 
 	$i18n = array(
-		'logPrefix'               => '[No-cache BFCache]',
+		'logPrefix'               => '[Instant Back/Forward]',
 		'pageRestored'            => __( 'Page restored from bfcache.', 'nocache-bfcache' ),
 		'pageInvalidating'        => __( 'Cached page is stale. Reloading...', 'nocache-bfcache' ),
 		'pageInvalidated'         => __( 'Page invalidated from cache via pageshow event handler.', 'nocache-bfcache' ),

--- a/nocache-bfcache.php
+++ b/nocache-bfcache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: No-cache BFCache
+ * Plugin Name: Instant Back/Forward
  * Plugin URI: https://github.com/westonruter/nocache-bfcache
  * Description: Enables back/forward cache (bfcache) for instant history navigations even when "nocache" headers are sent, such as when a user is logged in. <strong>To see the effect, you must log out and log back in again, ensuring "Remember Me" is checked.</strong>
  * Requires at least: 6.8

--- a/nocache-bfcache.php
+++ b/nocache-bfcache.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.8
  * Requires PHP: 7.2
  * Version: 1.3.0
- * Author: Weston Ruter
+ * Author: Weston Ruter, WordPress Performance Team
  * Author URI: https://weston.ruter.net/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
Fixes #48.

This also adds "Core Performance Team" as an author so that the plugin shows up when clicking this link in the Performance features screen:

<img width="753" height="47" alt="image" src="https://github.com/user-attachments/assets/d210369f-69a1-4294-a516-3dc2a0cc40bf" />

This link simply pre-populates a search for "Core Performance team":

<img width="564" height="57" alt="image" src="https://github.com/user-attachments/assets/7c86085c-1263-47f1-a25c-01f83be7f200" />
