### PR TITLE
v1.3.2: Use querySelector instead of getElementById for JSON script queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Enables back/forward cache (bfcache) for instant history navigations even when â
 **Contributors:** [westonruter](https://profile.wordpress.org/westonruter), [wordpressdotorg](https://profile.wordpress.org/wordpressdotorg), [performanceteam](https://profile.wordpress.org/performanceteam)  
 **Tags:**         performance, caching  
 **Tested up to:** 6.8  
-**Stable tag:**   1.3.1  
+**Stable tag:**   1.3.2  
 **License:**      [GPLv2 or later](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 
 ## Description
@@ -171,6 +171,10 @@ add_filter(
 ![Chrome DevTools showing successful bfcache navigation](.wordpress-org/screenshot-3.png)
 
 ## Changelog
+
+### 1.3.2
+
+* Add validation of the SCRIPT elements containing the script module data JSON. This fixes a DOM clobbering vulnerability in which an injected element with a colliding `id` could shadow a script and supply attacker-controlled data to the plugin's script modules, which required an authenticated user with at least a contributor role. Props to Asaf Mozes (amosec) for responsible disclosure.
 
 ### 1.3.1
 

--- a/js/bfcache-invalidation.js
+++ b/js/bfcache-invalidation.js
@@ -24,14 +24,25 @@
 const moduleId = '@nocache-bfcache/bfcache-invalidation';
 
 /**
+ * Selector for JSON script element.
+ *
+ * @since n.e.x.t
+ * @type {string}
+ */
+const jsonScriptSelector = `script[id="wp-script-module-data-${ moduleId }"]`;
+
+/**
  * JSON script containing the PHP exports.
  *
  * @since 1.0.0
- * @type {HTMLScriptElement}
+ * @type {HTMLScriptElement|null}
  */
-const jsonScript = /** @type {HTMLScriptElement} */ (
-	document.getElementById( `wp-script-module-data-${ moduleId }` )
+const jsonScript = /** @type {HTMLScriptElement|null} */ (
+	document.querySelector( jsonScriptSelector )
 );
+if ( ! ( jsonScript instanceof HTMLScriptElement ) ) {
+	throw new Error( `Missing: ${ jsonScriptSelector }` );
+}
 
 /**
  * Exports from PHP.

--- a/js/bfcache-invalidation.js
+++ b/js/bfcache-invalidation.js
@@ -26,7 +26,7 @@ const moduleId = '@nocache-bfcache/bfcache-invalidation';
 /**
  * Selector for JSON script element.
  *
- * @since n.e.x.t
+ * @since 1.3.2
  * @type {string}
  */
 const jsonScriptSelector = `script[id="wp-script-module-data-${ moduleId }"]`;

--- a/js/bfcache-opt-in.js
+++ b/js/bfcache-opt-in.js
@@ -18,7 +18,7 @@ const moduleId = '@nocache-bfcache/bfcache-opt-in';
 /**
  * Selector for JSON script element.
  *
- * @since n.e.x.t
+ * @since 1.3.2
  * @type {string}
  */
 const jsonScriptSelector = `script[id="wp-script-module-data-${ moduleId }"]`;

--- a/js/bfcache-opt-in.js
+++ b/js/bfcache-opt-in.js
@@ -16,14 +16,25 @@
 const moduleId = '@nocache-bfcache/bfcache-opt-in';
 
 /**
+ * Selector for JSON script element.
+ *
+ * @since n.e.x.t
+ * @type {string}
+ */
+const jsonScriptSelector = `script[id="wp-script-module-data-${ moduleId }"]`;
+
+/**
  * JSON script containing the PHP exports.
  *
  * @since 1.0.0
- * @type {HTMLScriptElement}
+ * @type {HTMLScriptElement|null}
  */
-const jsonScript = /** @type {HTMLScriptElement} */ (
-	document.getElementById( `wp-script-module-data-${ moduleId }` )
+const jsonScript = /** @type {HTMLScriptElement|null} */ (
+	document.querySelector( jsonScriptSelector )
 );
+if ( ! ( jsonScript instanceof HTMLScriptElement ) ) {
+	throw new Error( `Missing: ${ jsonScriptSelector }` );
+}
 
 /**
  * Exports from PHP.

--- a/js/detect-scripting-enabled-at-login.js
+++ b/js/detect-scripting-enabled-at-login.js
@@ -22,14 +22,25 @@
 const moduleId = '@nocache-bfcache/detect-scripting-enabled-at-login';
 
 /**
+ * Selector for JSON script element.
+ *
+ * @since n.e.x.t
+ * @type {string}
+ */
+const jsonScriptSelector = `script[id="wp-script-module-data-${ moduleId }"]`;
+
+/**
  * JSON script containing the PHP exports.
  *
  * @since 1.1.0
- * @type {HTMLScriptElement}
+ * @type {HTMLScriptElement|null}
  */
-const jsonScript = /** @type {HTMLScriptElement} */ (
-	document.getElementById( `wp-script-module-data-${ moduleId }` )
+const jsonScript = /** @type {HTMLScriptElement|null} */ (
+	document.querySelector( jsonScriptSelector )
 );
+if ( ! ( jsonScript instanceof HTMLScriptElement ) ) {
+	throw new Error( `Missing: ${ jsonScriptSelector }` );
+}
 
 /**
  * Exports from PHP.

--- a/js/detect-scripting-enabled-at-login.js
+++ b/js/detect-scripting-enabled-at-login.js
@@ -24,7 +24,7 @@ const moduleId = '@nocache-bfcache/detect-scripting-enabled-at-login';
 /**
  * Selector for JSON script element.
  *
- * @since n.e.x.t
+ * @since 1.3.2
  * @type {string}
  */
 const jsonScriptSelector = `script[id="wp-script-module-data-${ moduleId }"]`;

--- a/nocache-bfcache.php
+++ b/nocache-bfcache.php
@@ -5,7 +5,7 @@
  * Description: Enables back/forward cache (bfcache) for instant history navigations even when "nocache" headers are sent, such as when a user is logged in. <strong>To see the effect, you must log out and log back in again, ensuring "Remember Me" is checked.</strong>
  * Requires at least: 6.8
  * Requires PHP: 7.2
- * Version: 1.3.1
+ * Version: 1.3.2
  * Author: Weston Ruter, WordPress Performance Team
  * Author URI: https://weston.ruter.net/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( defined( 'BFCACHE_SESSION_TOKEN_COOKIE' ) || function_exists( 'wp_enqueue_b
  * @access private
  * @var string
  */
-const VERSION = '1.3.1';
+const VERSION = '1.3.2';
 
 /**
  * Plugin file.


### PR DESCRIPTION
Add validation of the SCRIPT elements containing the script module data JSON. This fixes a DOM clobbering vulnerability in which an injected element with a colliding `id` could shadow a script and supply attacker-controlled data to the plugin's script modules, which required an authenticated user with at least a contributor role. Props to Asaf Mozes (amosec) for responsible disclosure.